### PR TITLE
Pass through Meta.extra_kwargs

### DIFF
--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -63,6 +63,7 @@ class HalModelSerializer(NestedFieldsSerializerMixin, ModelSerializer):
             class Meta:
                 model = model_cls
                 fields = [api_settings.URL_FIELD_NAME] + link_field_names
+                extra_kwargs = getattr(self.Meta, 'extra_kwargs', {})
 
         return HalNestedLinksSerializer(instance=self.instance, source="*")
 
@@ -78,6 +79,7 @@ class HalModelSerializer(NestedFieldsSerializerMixin, ModelSerializer):
                 fields = embedded_field_names
                 nested_fields = defined_nested_fields
                 depth = embedded_depth
+                extra_kwargs = getattr(self.Meta, 'extra_kwargs', {})
 
         return HalNestedEmbeddedSerializer(source="*")
 


### PR DESCRIPTION
This enables a solution for issue #1 by allowing `view_name` to be passed down to the link fields, e.g.:

```
class ThingSerializer(HalModelSerializer):
    class Meta:
        model = Thing
        extra_kwargs = {
            'self': {
                'view_name': 'special-thing-detail',
            }
        }
```
