### PR TITLE
Ensure nested_fields is iterable

### DIFF
--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -69,6 +69,8 @@ class HalModelSerializer(NestedFieldsSerializerMixin, ModelSerializer):
 
     def _get_embedded_serializer(self, model_cls, embedded_depth, embedded_field_names):
         defined_nested_fields = getattr(self.Meta, "nested_fields", None)
+        if not defined_nested_fields:
+            defined_nested_fields = []
         nested_class = self.__class__
 
         class HalNestedEmbeddedSerializer(self.embedded_serializer_class):
@@ -82,7 +84,7 @@ class HalModelSerializer(NestedFieldsSerializerMixin, ModelSerializer):
                 extra_kwargs = getattr(self.Meta, 'extra_kwargs', {})
 
         return HalNestedEmbeddedSerializer(source="*")
-
+    
     @staticmethod
     def _is_link_field(field):
         return isinstance(field, RelatedField) or isinstance(field, ManyRelatedField) \

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='drf-hal-json',
-    version="0.9.1",
+    version="0.9.2",
     url='https://github.com/seebass/drf-hal-json',
     license='MIT',
     description='Extension for Django REST Framework 3 which allows for using content-type application/hal-json',


### PR DESCRIPTION
`drf_nested_fields` has lots of logic which assumes that if `nested_fields` is defined then it is iterable - e.g. [this](https://github.com/seebass/drf-nested-fields/blob/master/drf_nested_fields/serializers.py#L21). 